### PR TITLE
Add CLI output saving and multi-provider LLM fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Picture a glamorous library hour where every chapter pulls back the curtain on a
 - **Knowledge Agent** – our master of ceremonies who coordinates the troupe and cues new deep dives.
 - **Deep Dive Agents** – specialty performers who explore promising leads in detail.
 - **LLM Map-Reduce** – slices hefty HTML monologues into digestible acts and delivers polished recaps.
-- **LLM Client** – wraps GPT-4 (or other LLM backends) with graceful rate limiting and retries.
+- **LLM Client** – wraps GPT-4 with graceful rate limiting and now falls back to Anthropic and Mistral models when needed.
 
 ## Headline Acts (Features)
 - **Person Lookup Production** – generate summaries, psychological reads, resumes, phishing simulations (for research!), and even bespoke ads with a single command:
@@ -115,6 +115,8 @@ Prepare your secrets before stepping into the limelight:
 
 ```bash
 export OPENAI_API_KEY=your_openai_api_key
+export ANTHROPIC_API_KEY=your_anthropic_api_key   # optional fallback provider
+export MISTRAL_API_KEY=your_mistral_api_key       # optional fallback provider
 export SERPER_API_KEY=your_serper_api_key
 export SCRAPINGBEE_API_KEY=your_scrapingbee_api_key
 ```
@@ -129,6 +131,15 @@ Optional extras include `SCRAPING_DOG_API_KEY`, `FIRECRAWL_API_KEY`, and the new
   python -m kallisto_osinter.src.ui.qt_interface
   ```
 - **LangChain Pipeline** – orchestrate custom flows with `LangChainIntegrator` utilities.
+
+### Saving command output
+
+Both CLI entry points (`person_lookup` and `username_search`) now accept an optional `--output` flag to save results locally. The format is inferred from the file extension or can be forced with `--output-format` (`txt`, `md`, `csv`, or `json`).
+
+```bash
+python -m src.main person_lookup "Ada Lovelace" --ask "Provide a brief bio" --output reports/ada.md
+python -m src.main username_search ada --urls https://example.com --output usernames.json --output-format json
+```
 
 ## Testing
 Unit tests live in `tests/`. Run the full suite with:

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,5 @@ dnspython>=2.6.1
 aiohttp-socks==0.10.1
 python-socks[asyncio]>=2.4.3
 matplotlib
+anthropic
+mistralai

--- a/src/agents/knowledge_agent.py
+++ b/src/agents/knowledge_agent.py
@@ -19,7 +19,7 @@ class KnowledgeAgent:
         self.query = query
         self.config = config
         self.rounds = rounds
-        self.llm_client = LLMClient(config['OPENAI_API_KEY'])
+        self.llm_client = LLMClient.from_config(config)
         self.full_knowledge = ""
 
     def spawn_initial_agent(self):

--- a/src/agents/web_agent.py
+++ b/src/agents/web_agent.py
@@ -17,7 +17,7 @@ class WebAgent:
         self.query = query
         self.config = config
         self.deep_dive_topic = deep_dive_topic
-        self.llm_client = LLMClient(config['OPENAI_API_KEY'])
+        self.llm_client = LLMClient.from_config(config)
         self.results = []
         self.summary = ""
         self.lock = threading.Lock()

--- a/src/config.py
+++ b/src/config.py
@@ -20,6 +20,8 @@ def load_config() -> Dict[str, Any]:
 
     config: Dict[str, Any] = {
         "OPENAI_API_KEY": os.getenv("OPENAI_API_KEY", ""),
+        "ANTHROPIC_API_KEY": os.getenv("ANTHROPIC_API_KEY", ""),
+        "MISTRAL_API_KEY": os.getenv("MISTRAL_API_KEY", ""),
         "SERPER_API_KEY": os.getenv("SERPER_API_KEY", ""),
         "SCRAPINGBEE_API_KEY": os.getenv("SCRAPINGBEE_API_KEY", ""),
         "SCRAPING_DOG_API_KEY": os.getenv("SCRAPING_DOG_API_KEY", ""),

--- a/src/llm/llm_client.py
+++ b/src/llm/llm_client.py
@@ -1,53 +1,230 @@
-"""
-LLM Client module.
-Wraps calls to the LLM (e.g., GPT-4) using the OpenAI API with rate limiting.
+"""LLM Client module.
+
+Wraps calls to available large language model providers with rate limiting and
+fallback behaviour. The client will attempt to use OpenAI first, then Anthropic
+and finally Mistral if earlier providers fail.
 """
 
+from __future__ import annotations
+
 import time
-from openai import OpenAI
+from typing import Any, Dict, List, Optional
+
 from src.utils.logger import get_logger
+
+try:  # pragma: no cover - optional dependency
+    from openai import OpenAI
+except ImportError:  # pragma: no cover - handled gracefully
+    OpenAI = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency
+    from anthropic import Anthropic
+except ImportError:  # pragma: no cover - handled gracefully
+    Anthropic = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency
+    from mistralai.client import MistralClient
+    from mistralai.models.chat_completion import ChatMessage
+except ImportError:  # pragma: no cover - handled gracefully
+    MistralClient = None  # type: ignore
+    ChatMessage = None  # type: ignore
 
 logger = get_logger(__name__)
 
-# Global rate limiting for LLM calls
-_last_llm_call_time = 0
-_min_llm_call_interval = 2.0  # minimum seconds between LLM calls
+_DEFAULT_SYSTEM_PROMPT = "You are an OSINT assistant."
+
+_last_llm_call_time = 0.0
+
 
 class LLMClient:
-    def __init__(self, api_key):
-        self.api_key = api_key
-        self.client = OpenAI(api_key=api_key)
+    """Wrapper around multiple LLM providers with fallback support."""
 
-    def call_llm(self, prompt, model="gpt-4", temperature=0.7, max_tokens=512):
-        """
-        Calls the LLM with the given prompt and returns the response text.
-        Includes rate limiting to avoid API throttling.
-        """
+    def __init__(
+        self,
+        openai_key: Optional[str] = None,
+        anthropic_key: Optional[str] = None,
+        mistral_key: Optional[str] = None,
+        rate_limit: float = 2.0,
+        system_prompt: str = _DEFAULT_SYSTEM_PROMPT,
+    ) -> None:
+        self.rate_limit = max(rate_limit, 0.0)
+        self.system_prompt = system_prompt
+
+        self.openai_key = openai_key or ""
+        self.anthropic_key = anthropic_key or ""
+        self.mistral_key = mistral_key or ""
+
+        self.openai_client = self._build_openai_client()
+        self.anthropic_client = self._build_anthropic_client()
+        self.mistral_client = self._build_mistral_client()
+
+        self._provider_order: List[str] = []
+        if self.openai_client is not None:
+            self._provider_order.append("openai")
+        if self.anthropic_client is not None:
+            self._provider_order.append("anthropic")
+        if self.mistral_client is not None:
+            self._provider_order.append("mistral")
+
+        if not self._provider_order:
+            logger.warning("LLMClient initialized without any available providers.")
+
+    @classmethod
+    def from_config(cls, config: Dict[str, Any]) -> "LLMClient":
+        """Instantiate the client using a configuration dictionary."""
+
+        return cls(
+            openai_key=config.get("OPENAI_API_KEY"),
+            anthropic_key=config.get("ANTHROPIC_API_KEY"),
+            mistral_key=config.get("MISTRAL_API_KEY"),
+            rate_limit=float(config.get("LLM_RATE_LIMIT", 2.0)),
+        )
+
+    def _build_openai_client(self) -> Optional[OpenAI]:
+        if not self.openai_key or OpenAI is None:
+            return None
+        try:
+            return OpenAI(api_key=self.openai_key)
+        except Exception as exc:  # pragma: no cover - network failures
+            logger.error("Failed to initialize OpenAI client: %s", exc)
+            return None
+
+    def _build_anthropic_client(self) -> Optional[Anthropic]:
+        if not self.anthropic_key or Anthropic is None:
+            return None
+        try:
+            return Anthropic(api_key=self.anthropic_key)
+        except Exception as exc:  # pragma: no cover - network failures
+            logger.error("Failed to initialize Anthropic client: %s", exc)
+            return None
+
+    def _build_mistral_client(self) -> Optional[MistralClient]:
+        if not self.mistral_key or MistralClient is None:
+            return None
+        try:
+            return MistralClient(api_key=self.mistral_key)
+        except Exception as exc:  # pragma: no cover - network failures
+            logger.error("Failed to initialize Mistral client: %s", exc)
+            return None
+
+    def _respect_rate_limit(self) -> None:
         global _last_llm_call_time
-
-        # Rate limiting
+        if self.rate_limit <= 0:
+            return
         current_time = time.time()
-        time_since_last = current_time - _last_llm_call_time
-        if time_since_last < _min_llm_call_interval:
-            sleep_time = _min_llm_call_interval - time_since_last
+        elapsed = current_time - _last_llm_call_time
+        if elapsed < self.rate_limit:
+            sleep_time = self.rate_limit - elapsed
             logger.debug("LLM rate limiting: sleeping for %.2f seconds", sleep_time)
             time.sleep(sleep_time)
 
-        logger.debug("LLMClient: Calling LLM with prompt: %s", prompt[:100])
-        try:
-            response = self.client.chat.completions.create(
-                model=model,
-                messages=[{"role": "system", "content": "You are an OSINT assistant."},
-                          {"role": "user", "content": prompt}],
-                temperature=temperature,
-                max_tokens=max_tokens,
-                n=1,
-                stop=None,
-            )
-            _last_llm_call_time = time.time()
-            text = response.choices[0].message.content
-            return text.strip()
-        except Exception as e:
-            logger.error("LLM call failed: %s", str(e))
-            _last_llm_call_time = time.time()  # Update time even on error
-            return "LLM Error: Unable to process the request."
+    def call_llm(
+        self,
+        prompt: str,
+        model: str = "gpt-4",
+        temperature: float = 0.7,
+        max_tokens: int = 512,
+    ) -> str:
+        """Call the first available provider and return its response text."""
+
+        global _last_llm_call_time
+        self._respect_rate_limit()
+
+        for provider in self._provider_order:
+            try:
+                if provider == "openai":
+                    response = self._call_openai(prompt, model, temperature, max_tokens)
+                elif provider == "anthropic":
+                    response = self._call_anthropic(
+                        prompt,
+                        model="claude-3-sonnet-20240229",
+                        temperature=temperature,
+                        max_tokens=max_tokens,
+                    )
+                elif provider == "mistral":
+                    response = self._call_mistral(
+                        prompt,
+                        model="mistral-large-latest",
+                        temperature=temperature,
+                        max_tokens=max_tokens,
+                    )
+                else:  # pragma: no cover - defensive
+                    continue
+                _last_llm_call_time = time.time()
+                return response.strip()
+            except Exception as exc:
+                logger.error("LLM provider %s failed: %s", provider, exc)
+                _last_llm_call_time = time.time()
+
+        logger.error("All LLM providers failed to respond.")
+        return "LLM Error: Unable to process the request."
+
+    def _call_openai(
+        self,
+        prompt: str,
+        model: str,
+        temperature: float,
+        max_tokens: int,
+    ) -> str:
+        if self.openai_client is None:
+            raise RuntimeError("OpenAI client is not configured")
+
+        logger.debug("LLMClient(OpenAI): Calling model %s", model)
+        response = self.openai_client.chat.completions.create(
+            model=model,
+            messages=[
+                {"role": "system", "content": self.system_prompt},
+                {"role": "user", "content": prompt},
+            ],
+            temperature=temperature,
+            max_tokens=max_tokens,
+            n=1,
+        )
+        return response.choices[0].message.content or ""
+
+    def _call_anthropic(
+        self,
+        prompt: str,
+        model: str,
+        temperature: float,
+        max_tokens: int,
+    ) -> str:
+        if self.anthropic_client is None:
+            raise RuntimeError("Anthropic client is not configured")
+
+        logger.debug("LLMClient(Anthropic): Calling model %s", model)
+        response = self.anthropic_client.messages.create(
+            model=model,
+            system=self.system_prompt,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        if not response.content:
+            return ""
+        # The content is a list of blocks; concatenate text blocks
+        return "".join(block.text for block in response.content if hasattr(block, "text"))
+
+    def _call_mistral(
+        self,
+        prompt: str,
+        model: str,
+        temperature: float,
+        max_tokens: int,
+    ) -> str:
+        if self.mistral_client is None or ChatMessage is None:
+            raise RuntimeError("Mistral client is not configured")
+
+        logger.debug("LLMClient(Mistral): Calling model %s", model)
+        response = self.mistral_client.chat(
+            model=model,
+            messages=[
+                ChatMessage(role="system", content=self.system_prompt),
+                ChatMessage(role="user", content=prompt),
+            ],
+            temperature=temperature,
+            max_tokens=max_tokens,
+        )
+        if not response.choices:
+            return ""
+        return response.choices[0].message.content or ""

--- a/src/main.py
+++ b/src/main.py
@@ -1,35 +1,71 @@
-"""
-Main entry point for Kallisto-OSINTer.
-This script sets up the configuration, initializes logging and parses command-line arguments to trigger various OSINT tasks.
-"""
+"""Main entry point for Kallisto-OSINTer."""
+
+from __future__ import annotations
 
 import argparse
 import sys
-import os
+from pathlib import Path
+from typing import Any
+
 from src.config import load_config
 from src.modules import person_lookup, username_search
-from src.agents.knowledge_agent import KnowledgeAgent
 from src.utils.logger import get_logger
+from src.utils.output_saver import SUPPORTED_OUTPUT_FORMATS, save_results
 
 logger = get_logger(__name__)
 
-def parse_arguments():
+
+def _add_output_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--output",
+        type=str,
+        help="Optional path to persist command results.",
+    )
+    parser.add_argument(
+        "--output-format",
+        choices=sorted(SUPPORTED_OUTPUT_FORMATS),
+        help="Force an output format when saving results.",
+    )
+
+
+def parse_arguments() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Kallisto-OSINTer: LLM-based OSINT tool")
     subparsers = parser.add_subparsers(dest="command", required=True)
 
-    # Person lookup command
     lookup_parser = subparsers.add_parser("person_lookup", help="Lookup a person")
     lookup_parser.add_argument("name", type=str, help="Name of the person to lookup")
     lookup_parser.add_argument("--ask", type=str, required=True, help="Task to perform on the person info")
+    _add_output_arguments(lookup_parser)
 
-    # Username search command
     uname_parser = subparsers.add_parser("username_search", help="Search for a username across URLs")
     uname_parser.add_argument("username", type=str, help="Username to search")
     uname_parser.add_argument("--urls", type=str, nargs='+', required=True, help="List of URLs to search in")
+    _add_output_arguments(uname_parser)
 
     return parser.parse_args()
 
-def main():
+
+def _resolve_output_format(path: str, explicit_format: str | None) -> str:
+    if explicit_format:
+        return explicit_format
+    suffix = Path(path).suffix.lstrip(".")
+    if suffix:
+        return suffix
+    return "txt"
+
+
+def _maybe_save_results(data: Any, output_path: str | None, output_format: str | None) -> None:
+    if not output_path:
+        return
+    fmt = _resolve_output_format(output_path, output_format)
+    try:
+        saved_path = save_results(data, output_path, fmt)
+        print(f"Results saved to {saved_path}")
+    except ValueError as exc:
+        logger.error("Failed to save results: %s", exc)
+
+
+def main() -> None:
     config = load_config()
     args = parse_arguments()
 
@@ -37,14 +73,17 @@ def main():
         logger.info("Starting person lookup for %s", args.name)
         result = person_lookup.lookup_person(args.name, args.ask, config)
         print(result)
+        _maybe_save_results(result, args.output, args.output_format)
     elif args.command == "username_search":
         logger.info("Starting username search for %s", args.username)
         results = username_search.search_username(args.username, args.urls, config)
         for res in results:
             print(f"URL: {res['url']}, Status: {res['status']}")
-    else:
+        _maybe_save_results(results, args.output, args.output_format)
+    else:  # pragma: no cover - argparse enforces valid commands
         logger.error("Unknown command: %s", args.command)
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/src/modules/__init__.py
+++ b/src/modules/__init__.py
@@ -1,0 +1,6 @@
+"""Convenience exports for core OSINT modules."""
+
+from . import person_lookup as person_lookup
+from . import username_search as username_search
+
+__all__ = ["person_lookup", "username_search"]

--- a/src/modules/person_lookup.py
+++ b/src/modules/person_lookup.py
@@ -1,29 +1,23 @@
-"""
-Person Lookup module.
-Given a person's name and a task (question), uses the KnowledgeAgent to gather information and then answers the question.
+"""Person Lookup module.
+
+Given a person's name and a task (question), uses the KnowledgeAgent to gather
+information and then answers the question.
 """
 
+from __future__ import annotations
+
 from src.agents.knowledge_agent import KnowledgeAgent
-from src.llm.llm_client import LLMClient
 from src.utils.logger import get_logger
 
 logger = get_logger(__name__)
 
-def lookup_person(name, question, config):
-    """
-    Lookup a person by:
-      1. Using the KnowledgeAgent to gather information.
-      2. Feeding the full knowledge base to the LLM client to answer the question.
-    """
+
+def lookup_person(name: str, question: str, config: dict) -> str:
+    """Return an answer about ``name`` based on the supplied ``question``."""
+
     logger.info("Initiating person lookup for: %s", name)
-    # Prepare initial query and instantiate KnowledgeAgent
     query = f"Learn as much as you can about {name}"
     knowledge_agent = KnowledgeAgent(query, config, rounds=2)
-    full_knowledge = knowledge_agent.aggregate_knowledge()
-    
-    # Answer the question using the aggregated knowledge
+    knowledge_agent.aggregate_knowledge()
     answer = knowledge_agent.answer_final_question(question)
-    
-    # Optionally, format answer (e.g., create markdown resume, tables, etc.)
-    # For now, we simply return the answer
     return answer

--- a/src/modules/username_search.py
+++ b/src/modules/username_search.py
@@ -1,31 +1,34 @@
-"""
-Username Search module.
-Searches a list of URLs concurrently for a specified username.
-Utilizes threading, proxies, and randomized user agents.
+"""Username Search module.
+
+Searches a list of URLs concurrently for a specified username. Utilises
+threading, proxies, and randomized user agents.
 """
 
+from __future__ import annotations
+
 import threading
+from typing import Dict, List
+
 import requests
+
+from src.utils.logger import get_logger
 from src.utils.proxies import validate_proxies
 from src.utils.user_agents import get_random_user_agent
-from src.utils.logger import get_logger
 
 logger = get_logger(__name__)
 
-def search_username(username, urls, config):
-    """
-    For each URL, check if the username appears in the content.
-    Returns a list of dictionaries with URL and HTTP status.
-    """
-    results = []
+
+def search_username(username: str, urls: List[str], config: dict) -> List[Dict[str, str]]:
+    """Check each URL for ``username`` and return discovery metadata."""
+
+    results: List[Dict[str, str]] = []
     threads = []
     lock = threading.Lock()
 
-    # Validate proxies if available
     proxy_list = config.get("PROXY_LIST", [])
     valid_proxies = validate_proxies(proxy_list) if proxy_list else []
 
-    def worker(url):
+    def worker(url: str) -> None:
         headers = {"User-Agent": get_random_user_agent()}
         proxy = {"http": valid_proxies[0], "https": valid_proxies[0]} if valid_proxies else None
         try:
@@ -33,17 +36,17 @@ def search_username(username, urls, config):
             content = response.text
             found = username.lower() in content.lower()
             status = "found" if found else "not found"
-        except Exception as e:
-            status = f"error: {str(e)}"
+        except Exception as exc:  # pragma: no cover - network/requests failures
+            status = f"error: {exc}"
         with lock:
             results.append({"url": url, "status": status})
 
     for url in urls:
-        t = threading.Thread(target=worker, args=(url,))
-        t.start()
-        threads.append(t)
+        thread = threading.Thread(target=worker, args=(url,))
+        thread.start()
+        threads.append(thread)
 
-    for t in threads:
-        t.join()
+    for thread in threads:
+        thread.join()
 
     return results

--- a/src/tests/test_llm.py
+++ b/src/tests/test_llm.py
@@ -1,27 +1,25 @@
-"""
-Unit tests for the LLM module.
-Uses Python's built-in unittest framework.
-"""
+"""Unit tests for the LLM module."""
+
+from __future__ import annotations
 
 import unittest
+
 from src.llm.llm_client import LLMClient
 
-class TestLLMClient(unittest.TestCase):
-    def setUp(self):
-        # Use a dummy API key for testing; in practice, you might mock openai.
-        self.llm_client = LLMClient(api_key="dummy_key")
 
-    def test_call_llm_returns_string(self):
+class TestLLMClient(unittest.TestCase):
+    def setUp(self) -> None:
+        self.llm_client = LLMClient()
+
+    def test_call_llm_returns_string(self) -> None:
         prompt = "Summarize the following text: Hello world."
-        # Here we simulate a call by overriding the function if needed.
         response = self.llm_client.call_llm(prompt)
         self.assertIsInstance(response, str)
 
-    def test_call_llm_error_handling(self):
-        # Intentionally pass a prompt that causes an error (simulate by passing empty API key)
-        self.llm_client.api_key = ""
+    def test_call_llm_error_handling(self) -> None:
         response = self.llm_client.call_llm("Test prompt")
-        self.assertTrue("LLM Error" in response)
+        self.assertIn("LLM Error", response)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/utils/output_saver.py
+++ b/src/utils/output_saver.py
@@ -1,0 +1,77 @@
+"""Utility helpers for persisting command results to disk."""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+from typing import List
+
+from src.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+SUPPORTED_OUTPUT_FORMATS = {"txt", "md", "csv", "json"}
+
+
+def _ensure_directory(path: Path) -> None:
+    if path.parent.exists():
+        return
+    logger.debug("Creating parent directory for %s", path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def _normalise_csv_rows(data: object) -> tuple[List[str], List[List[str]]]:
+    """Return CSV headers and rows derived from arbitrary data."""
+
+    if isinstance(data, list):
+        if not data:
+            return [], []
+        if isinstance(data[0], dict):
+            headers = sorted({key for row in data for key in row.keys()})
+            rows: List[List[str]] = [
+                [str(row.get(header, "")) for header in headers]
+                for row in data
+            ]
+            return headers, rows
+        return ["value"], [[str(item)] for item in data]
+
+    if isinstance(data, dict):
+        headers = ["key", "value"]
+        rows = [[str(key), str(value)] for key, value in data.items()]
+        return headers, rows
+
+    return ["value"], [[str(data)]]
+
+
+def save_results(data: object, output_path: str, output_format: str | None = None) -> Path:
+    """Persist ``data`` to ``output_path`` in the requested format."""
+
+    path = Path(output_path)
+    fmt = (output_format or path.suffix.lstrip(".")).lower()
+    if fmt not in SUPPORTED_OUTPUT_FORMATS:
+        raise ValueError(
+            f"Unsupported output format '{fmt}'. Supported formats: {sorted(SUPPORTED_OUTPUT_FORMATS)}"
+        )
+
+    if not path.suffix and output_format:
+        path = path.with_suffix(f".{fmt}")
+
+    _ensure_directory(path)
+
+    if fmt in {"txt", "md"}:
+        text = data if isinstance(data, str) else json.dumps(data, indent=2, ensure_ascii=False)
+        path.write_text(str(text), encoding="utf-8")
+    elif fmt == "json":
+        with path.open("w", encoding="utf-8") as handle:
+            json.dump(data, handle, indent=2, ensure_ascii=False)
+    else:  # fmt == "csv"
+        headers, rows = _normalise_csv_rows(data)
+        with path.open("w", encoding="utf-8", newline="") as handle:
+            writer = csv.writer(handle)
+            if headers:
+                writer.writerow(headers)
+            writer.writerows(rows)
+
+    logger.info("Saved results to %s", path)
+    return path


### PR DESCRIPTION
## Summary
- add a reusable result saving utility and expose CLI flags to persist command output in text, markdown, CSV, or JSON
- extend configuration and the LLM client to accept Anthropic and Mistral API keys and fail over when OpenAI is unavailable
- document the new capabilities in the README and include the additional dependencies

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'src' when collecting tests)*
- `PYTHONPATH=. pytest src/tests/test_llm.py`


------
https://chatgpt.com/codex/tasks/task_e_68e30626dc0c8321ba474f3d525a68e7

## Summary by Sourcery

Add CLI output saving utility and flags for persisting command results in various formats, and extend the LLM client to accept Anthropic and Mistral API keys with automatic provider fallback.

New Features:
- Introduce --output and --output-format CLI flags to save command results as txt, md, csv, or json.
- Add output_saver utility to persist data in text, markdown, CSV, or JSON formats.
- Enable LLMClient to accept Anthropic and Mistral API keys and automatically fall back when OpenAI is unavailable.

Enhancements:
- Refactor LLMClient to unify provider initialization, rate limiting, and per-provider call methods.
- Update KnowledgeAgent and WebAgent to instantiate LLMClient from configuration.
- Add type annotations, improved logging, and module export consolidation in core modules.

Documentation:
- Document new CLI flags and multi-provider LLM fallback in README with examples.
- List Anthropic and Mistral as optional dependencies and update requirements.txt.

Tests:
- Adjust LLMClient unit tests to match new constructor and error handling behavior.

Chores:
- Add src/utils/output_saver.py and consolidate module exports in src/modules/__init__.py.