### PR TITLE
Refactor LLM client configuration and improve concurrency handling

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+testpaths = src/tests
+pythonpath =
+    .

--- a/src/config.py
+++ b/src/config.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import os
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 
 def _env_to_bool(value: str | None, default: bool = False) -> bool:
@@ -17,6 +17,16 @@ def _env_to_bool(value: str | None, default: bool = False) -> bool:
 
 def load_config() -> Dict[str, Any]:
     """Load configuration from environment variables."""
+
+    provider_order_env = os.getenv("LLM_PROVIDER_ORDER")
+    if provider_order_env:
+        provider_order: List[str] = [
+            item.strip().lower()
+            for item in provider_order_env.split(",")
+            if item.strip()
+        ]
+    else:
+        provider_order = ["openai", "anthropic", "mistral"]
 
     config: Dict[str, Any] = {
         "OPENAI_API_KEY": os.getenv("OPENAI_API_KEY", ""),
@@ -33,6 +43,13 @@ def load_config() -> Dict[str, Any]:
         "PROXY_LIST": os.getenv("PROXY_LIST", "[]"),
         "LLM_RATE_LIMIT": float(os.getenv("LLM_RATE_LIMIT", "2.0")),
         "SEARCH_RATE_LIMIT": float(os.getenv("SEARCH_RATE_LIMIT", "1.5")),
+        "USERNAME_SEARCH_MAX_WORKERS": int(os.getenv("USERNAME_SEARCH_MAX_WORKERS", "10")),
+        "LLM_PROVIDER_ORDER": provider_order,
+        "LLM_MODEL_OVERRIDES": {
+            "openai": os.getenv("LLM_MODEL_OPENAI", "gpt-4"),
+            "anthropic": os.getenv("LLM_MODEL_ANTHROPIC", "claude-3-sonnet-20240229"),
+            "mistral": os.getenv("LLM_MODEL_MISTRAL", "mistral-large-latest"),
+        },
         "DEBUG_MODE": _env_to_bool(os.getenv("KALLISTO_DEBUG")),
         "LOG_LEVEL": os.getenv("KALLISTO_LOG_LEVEL"),
     }

--- a/src/main.py
+++ b/src/main.py
@@ -48,10 +48,7 @@ def parse_arguments() -> argparse.Namespace:
 def _resolve_output_format(path: str, explicit_format: str | None) -> str:
     if explicit_format:
         return explicit_format
-    suffix = Path(path).suffix.lstrip(".")
-    if suffix:
-        return suffix
-    return "txt"
+    return suffix if (suffix := Path(path).suffix.lstrip(".")) else "txt"
 
 
 def _maybe_save_results(data: Any, output_path: str | None, output_format: str | None) -> None:
@@ -63,6 +60,7 @@ def _maybe_save_results(data: Any, output_path: str | None, output_format: str |
         print(f"Results saved to {saved_path}")
     except ValueError as exc:
         logger.error("Failed to save results: %s", exc)
+        print(f"Error: Failed to save results to {output_path}: {exc}")
 
 
 def main() -> None:

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Test configuration for pytest discovery."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SRC_PATH = Path(__file__).resolve().parents[1]
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))

--- a/src/tests/test_llm.py
+++ b/src/tests/test_llm.py
@@ -3,22 +3,78 @@
 from __future__ import annotations
 
 import unittest
+from unittest.mock import MagicMock
 
 from src.llm.llm_client import LLMClient
 
 
 class TestLLMClient(unittest.TestCase):
     def setUp(self) -> None:
-        self.llm_client = LLMClient()
+        self.llm_client = LLMClient(rate_limit=0)
 
     def test_call_llm_returns_string(self) -> None:
         prompt = "Summarize the following text: Hello world."
+        provider_mock = MagicMock(return_value="summary")
+        self.llm_client._providers = [("openai", provider_mock)]
         response = self.llm_client.call_llm(prompt)
-        self.assertIsInstance(response, str)
+        self.assertEqual(response, "summary")
+        provider_mock.assert_called_once()
 
     def test_call_llm_error_handling(self) -> None:
+        providers = ["openai", "anthropic", "mistral"]
+        for provider in providers:
+            with self.subTest(provider=provider):
+                llm_client = LLMClient(rate_limit=0)
+                failing_mock = MagicMock(side_effect=Exception(f"{provider} failure"))
+                llm_client._providers = [(provider, failing_mock)]
+                response = llm_client.call_llm("Test prompt")
+                self.assertIn("LLM Error", response)
+                failing_mock.assert_called_once()
+
+    def test_call_llm_all_providers_fail_returns_error(self) -> None:
+        openai_mock = MagicMock(side_effect=Exception("OpenAI failure"))
+        anthropic_mock = MagicMock(side_effect=Exception("Anthropic failure"))
+        mistral_mock = MagicMock(side_effect=Exception("Mistral failure"))
+        self.llm_client._providers = [
+            ("openai", openai_mock),
+            ("anthropic", anthropic_mock),
+            ("mistral", mistral_mock),
+        ]
         response = self.llm_client.call_llm("Test prompt")
         self.assertIn("LLM Error", response)
+        openai_mock.assert_called_once()
+        anthropic_mock.assert_called_once()
+        mistral_mock.assert_called_once()
+
+    def test_fallback_to_anthropic_when_openai_fails(self) -> None:
+        openai_mock = MagicMock(side_effect=Exception("OpenAI failure"))
+        anthropic_mock = MagicMock(return_value="Anthropic response")
+        mistral_mock = MagicMock(return_value="Mistral response")
+        self.llm_client._providers = [
+            ("openai", openai_mock),
+            ("anthropic", anthropic_mock),
+            ("mistral", mistral_mock),
+        ]
+        response = self.llm_client.call_llm("Test prompt")
+        self.assertEqual(response, "Anthropic response")
+        openai_mock.assert_called_once()
+        anthropic_mock.assert_called_once()
+        mistral_mock.assert_not_called()
+
+    def test_fallback_to_mistral_when_openai_and_anthropic_fail(self) -> None:
+        openai_mock = MagicMock(side_effect=Exception("OpenAI failure"))
+        anthropic_mock = MagicMock(side_effect=Exception("Anthropic failure"))
+        mistral_mock = MagicMock(return_value="Mistral response")
+        self.llm_client._providers = [
+            ("openai", openai_mock),
+            ("anthropic", anthropic_mock),
+            ("mistral", mistral_mock),
+        ]
+        response = self.llm_client.call_llm("Test prompt")
+        self.assertEqual(response, "Mistral response")
+        openai_mock.assert_called_once()
+        anthropic_mock.assert_called_once()
+        mistral_mock.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/src/utils/output_saver.py
+++ b/src/utils/output_saver.py
@@ -54,7 +54,7 @@ def save_results(data: object, output_path: str, output_format: str | None = Non
             f"Unsupported output format '{fmt}'. Supported formats: {sorted(SUPPORTED_OUTPUT_FORMATS)}"
         )
 
-    if not path.suffix and output_format:
+    if not path.suffix:
         path = path.with_suffix(f".{fmt}")
 
     _ensure_directory(path)


### PR DESCRIPTION
## Summary
- refactor the LLM client to use a provider registry with instance-scoped rate limiting and configuration-driven provider ordering/model selection
- expose provider order, model, and username search concurrency controls via configuration while hardening output saving feedback and suffix handling
- expand LLM client unit tests and add pytest configuration/bootstrap files for reliable module discovery

## Testing
- pytest src/tests/test_llm.py

------
https://chatgpt.com/codex/tasks/task_e_68e309270d588321917b6063ac89b1cf