### PR TITLE
Improve LLM client rate limiting and diagnostics

### DIFF
--- a/src/tests/test_llm.py
+++ b/src/tests/test_llm.py
@@ -29,6 +29,7 @@ class TestLLMClient(unittest.TestCase):
                 llm_client._providers = [(provider, failing_mock)]
                 response = llm_client.call_llm("Test prompt")
                 self.assertIn("LLM Error", response)
+                self.assertIn(f"{provider} failure", response)
                 failing_mock.assert_called_once()
 
     def test_call_llm_all_providers_fail_returns_error(self) -> None:
@@ -42,6 +43,9 @@ class TestLLMClient(unittest.TestCase):
         ]
         response = self.llm_client.call_llm("Test prompt")
         self.assertIn("LLM Error", response)
+        self.assertIn("OpenAI failure", response)
+        self.assertIn("Anthropic failure", response)
+        self.assertIn("Mistral failure", response)
         openai_mock.assert_called_once()
         anthropic_mock.assert_called_once()
         mistral_mock.assert_called_once()
@@ -75,6 +79,39 @@ class TestLLMClient(unittest.TestCase):
         openai_mock.assert_called_once()
         anthropic_mock.assert_called_once()
         mistral_mock.assert_called_once()
+
+    def test_no_providers_returns_error_message(self) -> None:
+        self.llm_client._providers = []
+        response = self.llm_client.call_llm("Test prompt")
+        self.assertEqual(response, "LLM Error: No providers are configured.")
+
+    def test_custom_provider_order_is_respected(self) -> None:
+        anthropic_mock = MagicMock(return_value="Anthropic response")
+        openai_mock = MagicMock(return_value="OpenAI response")
+        self.llm_client.anthropic_client = object()
+        self.llm_client.openai_client = object()
+        self.llm_client._call_anthropic = anthropic_mock  # type: ignore[attr-defined]
+        self.llm_client._call_openai = openai_mock  # type: ignore[attr-defined]
+        self.llm_client._providers = self.llm_client._build_provider_registry(
+            ["anthropic", "openai"]
+        )
+        response = self.llm_client.call_llm("Test prompt")
+        self.assertEqual(response, "Anthropic response")
+        anthropic_mock.assert_called_once()
+        openai_mock.assert_not_called()
+
+    def test_model_overrides_are_applied(self) -> None:
+        provider_mock = MagicMock(return_value="Summary")
+        self.llm_client.openai_client = object()
+        self.llm_client._call_openai = provider_mock  # type: ignore[attr-defined]
+        self.llm_client._providers = self.llm_client._build_provider_registry(["openai"])
+        response = self.llm_client.call_llm(
+            "Prompt", model_overrides={"openai": "gpt-custom"}
+        )
+        self.assertEqual(response, "Summary")
+        provider_mock.assert_called_once()
+        _, model_arg, _, _ = provider_mock.call_args[0]
+        self.assertEqual(model_arg, "gpt-custom")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- switch LLM rate limiting to use a monotonic clock and factor constructor logic into focused helpers
- tighten provider ordering behaviour, aggregate provider failure diagnostics, and surface missing provider configurations
- parse proxy list environment values into sequences and expand LLM client tests for ordering, overrides, and empty provider coverage

## Testing
- pytest *(fails: missing `langchain_community` dependency and system `libGL.so.1` for Qt tests)*

------
https://chatgpt.com/codex/tasks/task_e_68e30f1670b08321947e559adea0111b

## Summary by Sourcery

Improve rate-limiting accuracy, refactor LLM client initialization and provider ordering, enhance failure diagnostics, parse proxy list env variables, and expand related tests

Enhancements:
- Refactor LLMClient initialization by extracting provider model loading, client construction, and provider registry assembly into dedicated helper methods
- Replace time-based rate limiting with monotonic clock and consolidate rate-limiting logic into a single apply_rate_limit method
- Enforce and log provider ordering, fallback to default order when invalid, and surface an explicit error when no providers are configured
- Collect and aggregate individual provider failure messages, returning detailed diagnostics in the error response
- Update config loader to interpret PROXY_LIST environment variable as JSON array or comma-separated string, producing a clean list of proxies

Tests:
- Expand LLM client tests to cover no providers error, custom provider order, and model override scenarios