### PR TITLE
Add Kilocode ChatGPT 3.5 integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ Prepare your secrets before stepping into the limelight:
 export OPENAI_API_KEY=your_openai_api_key
 export ANTHROPIC_API_KEY=your_anthropic_api_key   # optional fallback provider
 export MISTRAL_API_KEY=your_mistral_api_key       # optional fallback provider
+export KILOCODE_API_KEY=your_kilocode_api_key     # optional ChatGPT 3.5 via Kilocode
+# export KILOCODE_API_BASE=https://api.kilocode.com/v1  # override Kilocode endpoint if needed
 export SERPER_API_KEY=your_serper_api_key
 export SCRAPINGBEE_API_KEY=your_scrapingbee_api_key
 ```

--- a/src/config.py
+++ b/src/config.py
@@ -25,12 +25,14 @@ def load_config() -> Dict[str, Any]:
             if item.strip()
         ]
     else:
-        provider_order = ["openai", "anthropic", "mistral"]
+        provider_order = ["openai", "anthropic", "mistral", "kilocode"]
 
     config: Dict[str, Any] = {
         "OPENAI_API_KEY": os.getenv("OPENAI_API_KEY", ""),
         "ANTHROPIC_API_KEY": os.getenv("ANTHROPIC_API_KEY", ""),
         "MISTRAL_API_KEY": os.getenv("MISTRAL_API_KEY", ""),
+        "KILOCODE_API_KEY": os.getenv("KILOCODE_API_KEY", ""),
+        "KILOCODE_API_BASE": os.getenv("KILOCODE_API_BASE", "https://api.kilocode.com/v1"),
         "SERPER_API_KEY": os.getenv("SERPER_API_KEY", ""),
         "SCRAPINGBEE_API_KEY": os.getenv("SCRAPINGBEE_API_KEY", ""),
         "SCRAPING_DOG_API_KEY": os.getenv("SCRAPING_DOG_API_KEY", ""),
@@ -48,6 +50,7 @@ def load_config() -> Dict[str, Any]:
             "openai": os.getenv("LLM_MODEL_OPENAI", "gpt-4"),
             "anthropic": os.getenv("LLM_MODEL_ANTHROPIC", "claude-3-sonnet-20240229"),
             "mistral": os.getenv("LLM_MODEL_MISTRAL", "mistral-large-latest"),
+            "kilocode": os.getenv("LLM_MODEL_KILOCODE", "gpt-3.5-turbo"),
         },
         "DEBUG_MODE": _env_to_bool(os.getenv("KALLISTO_DEBUG")),
         "LOG_LEVEL": os.getenv("KALLISTO_LOG_LEVEL"),

--- a/src/llm/llm_client.py
+++ b/src/llm/llm_client.py
@@ -30,15 +30,23 @@ except ImportError:  # pragma: no cover - handled gracefully
     MistralClient = None  # type: ignore
     ChatMessage = None  # type: ignore
 
+try:  # pragma: no cover - optional dependency
+    import requests
+    from requests.exceptions import RequestException
+except ImportError:  # pragma: no cover - handled gracefully
+    requests = None  # type: ignore
+    RequestException = Exception  # type: ignore[misc, assignment]
+
 logger = get_logger(__name__)
 
 _DEFAULT_SYSTEM_PROMPT = "You are an OSINT assistant."
-_SUPPORTED_PROVIDERS = ("openai", "anthropic", "mistral")
+_SUPPORTED_PROVIDERS = ("openai", "anthropic", "mistral", "kilocode")
 _DEFAULT_PROVIDER_ORDER = list(_SUPPORTED_PROVIDERS)
 _DEFAULT_PROVIDER_MODELS = {
     "openai": "gpt-4",
     "anthropic": "claude-3-sonnet-20240229",
     "mistral": "mistral-large-latest",
+    "kilocode": "gpt-3.5-turbo",
 }
 
 
@@ -50,10 +58,12 @@ class LLMClient:
         openai_key: Optional[str] = None,
         anthropic_key: Optional[str] = None,
         mistral_key: Optional[str] = None,
+        kilocode_key: Optional[str] = None,
         provider_order: Optional[Sequence[str]] = None,
         models: Optional[Dict[str, str]] = None,
         rate_limit: float = 2.0,
         system_prompt: str = _DEFAULT_SYSTEM_PROMPT,
+        kilocode_base_url: str = "https://api.kilocode.com/v1",
     ) -> None:
         self.rate_limit = max(rate_limit, 0.0)
         self._rate_limit_lock = threading.Lock()
@@ -63,6 +73,8 @@ class LLMClient:
         self.openai_key = (openai_key or "").strip()
         self.anthropic_key = (anthropic_key or "").strip()
         self.mistral_key = (mistral_key or "").strip()
+        self.kilocode_key = (kilocode_key or "").strip()
+        self.kilocode_base_url = kilocode_base_url.rstrip("/") or "https://api.kilocode.com/v1"
 
         self._provider_models = self._initialise_provider_models(models)
 
@@ -82,10 +94,12 @@ class LLMClient:
             openai_key=config.get("OPENAI_API_KEY"),
             anthropic_key=config.get("ANTHROPIC_API_KEY"),
             mistral_key=config.get("MISTRAL_API_KEY"),
+            kilocode_key=config.get("KILOCODE_API_KEY"),
             rate_limit=float(config.get("LLM_RATE_LIMIT", 2.0)),
             provider_order=config.get("LLM_PROVIDER_ORDER"),
             models=config.get("LLM_MODEL_OVERRIDES"),
             system_prompt=config.get("LLM_SYSTEM_PROMPT", _DEFAULT_SYSTEM_PROMPT),
+            kilocode_base_url=config.get("KILOCODE_API_BASE", "https://api.kilocode.com/v1"),
         )
 
     def _initialise_provider_models(
@@ -107,6 +121,9 @@ class LLMClient:
         self.openai_client = self._build_client(self.openai_key, OpenAI, "OpenAI")
         self.anthropic_client = self._build_client(self.anthropic_key, Anthropic, "Anthropic")
         self.mistral_client = self._build_client(self.mistral_key, MistralClient, "Mistral")
+        if self.kilocode_key and requests is None:
+            logger.error("Requests library is required for Kilocode provider but is not installed.")
+        self.kilocode_client = self.kilocode_key if self.kilocode_key and requests is not None else None
 
     def _build_provider_registry(
         self, order: Sequence[str]
@@ -284,3 +301,63 @@ class LLMClient:
             max_tokens=max_tokens,
         )
         return response.choices[0].message.content or "" if response.choices else ""
+
+    def _call_kilocode(
+        self,
+        prompt: str,
+        model: str,
+        temperature: float,
+        max_tokens: int,
+    ) -> str:
+        if not self.kilocode_client:
+            raise RuntimeError("Kilocode client is not configured")
+        if requests is None:  # pragma: no cover - safety guard
+            raise RuntimeError("Requests library is unavailable")
+
+        url = f"{self.kilocode_base_url}/chat/completions"
+        headers = {
+            "Authorization": f"Bearer {self.kilocode_key}",
+            "X-API-Key": self.kilocode_key,
+            "Content-Type": "application/json",
+        }
+        payload = {
+            "model": model or self._provider_models.get("kilocode", "gpt-3.5-turbo"),
+            "messages": [
+                {"role": "system", "content": self.system_prompt},
+                {"role": "user", "content": prompt},
+            ],
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+        }
+
+        try:
+            response = requests.post(url, headers=headers, json=payload, timeout=30)
+        except RequestException as exc:  # pragma: no cover - network failure
+            raise RuntimeError(f"Kilocode request failed: {exc}") from exc
+
+        try:
+            response.raise_for_status()
+        except Exception as exc:  # pragma: no cover - HTTP errors
+            raise RuntimeError(
+                f"Kilocode HTTP {getattr(response, 'status_code', 'unknown')}: {getattr(response, 'text', '')}"
+            ) from exc
+
+        try:
+            data = response.json()
+        except ValueError as exc:
+            raise RuntimeError("Kilocode returned a non-JSON response") from exc
+
+        choices = data.get("choices")
+        if not choices:
+            return ""
+        first_choice = choices[0] or {}
+        message = first_choice.get("message", {})
+        if isinstance(message, dict):
+            content = message.get("content", "")
+        else:
+            content = message or ""
+
+        if isinstance(content, list):
+            content = "".join(str(part) for part in content)
+
+        return str(content).strip()


### PR DESCRIPTION
## Summary
- add Kilocode ChatGPT 3.5 provider support to the LLM client with HTTP integration and request handling
- expose Kilocode configuration through environment variables and document the new options in the README
- expand LLM client tests to cover Kilocode error handling and fallback behaviour

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'langchain_community'; ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68e32c6522f0832181263c5914f3c34f

## Summary by Sourcery

Integrate Kilocode ChatGPT 3.5 as a new fallback provider in the LLM client, including HTTP-based request handling, environment-based configuration, updated provider order and error handling, plus corresponding tests and documentation updates.

New Features:
- Add Kilocode ChatGPT 3.5 provider support with an HTTP-based _call_kilocode implementation and fallback integration

Enhancements:
- Introduce optional requests dependency and expose KILOCODE_API_KEY and KILOCODE_API_BASE in the configuration

Documentation:
- Document new Kilocode environment variables and configuration options in the README

Tests:
- Expand LLM client tests to cover Kilocode provider error handling and fallback behavior