### PR TITLE
Add Kilocode ChatGPT 3.5 integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ Prepare your secrets before stepping into the limelight:
 export OPENAI_API_KEY=your_openai_api_key
 export ANTHROPIC_API_KEY=your_anthropic_api_key   # optional fallback provider
 export MISTRAL_API_KEY=your_mistral_api_key       # optional fallback provider
+export KILOCODE_API_KEY=your_kilocode_api_key     # optional ChatGPT 3.5 via Kilocode
+# export KILOCODE_API_BASE=https://api.kilocode.com/v1  # override Kilocode endpoint if needed
 export SERPER_API_KEY=your_serper_api_key
 export SCRAPINGBEE_API_KEY=your_scrapingbee_api_key
 ```

--- a/src/config.py
+++ b/src/config.py
@@ -25,12 +25,14 @@ def load_config() -> Dict[str, Any]:
             if item.strip()
         ]
     else:
-        provider_order = ["openai", "anthropic", "mistral"]
+        provider_order = ["openai", "anthropic", "mistral", "kilocode"]
 
     config: Dict[str, Any] = {
         "OPENAI_API_KEY": os.getenv("OPENAI_API_KEY", ""),
         "ANTHROPIC_API_KEY": os.getenv("ANTHROPIC_API_KEY", ""),
         "MISTRAL_API_KEY": os.getenv("MISTRAL_API_KEY", ""),
+        "KILOCODE_API_KEY": os.getenv("KILOCODE_API_KEY", ""),
+        "KILOCODE_API_BASE": os.getenv("KILOCODE_API_BASE", "https://api.kilocode.com/v1"),
         "SERPER_API_KEY": os.getenv("SERPER_API_KEY", ""),
         "SCRAPINGBEE_API_KEY": os.getenv("SCRAPINGBEE_API_KEY", ""),
         "SCRAPING_DOG_API_KEY": os.getenv("SCRAPING_DOG_API_KEY", ""),
@@ -48,6 +50,7 @@ def load_config() -> Dict[str, Any]:
             "openai": os.getenv("LLM_MODEL_OPENAI", "gpt-4"),
             "anthropic": os.getenv("LLM_MODEL_ANTHROPIC", "claude-3-sonnet-20240229"),
             "mistral": os.getenv("LLM_MODEL_MISTRAL", "mistral-large-latest"),
+            "kilocode": os.getenv("LLM_MODEL_KILOCODE", "gpt-3.5-turbo"),
         },
         "DEBUG_MODE": _env_to_bool(os.getenv("KALLISTO_DEBUG")),
         "LOG_LEVEL": os.getenv("KALLISTO_LOG_LEVEL"),

--- a/src/llm/kilocode_client.py
+++ b/src/llm/kilocode_client.py
@@ -1,0 +1,124 @@
+"""Kilocode LLM client utilities."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from src.utils.logger import get_logger
+
+try:  # pragma: no cover - optional dependency
+    import requests
+    from requests.exceptions import RequestException
+except ImportError:  # pragma: no cover - handled gracefully
+    requests = None  # type: ignore
+    RequestException = Exception  # type: ignore[misc, assignment]
+
+
+logger = get_logger(__name__)
+
+
+class KilocodeClient:
+    """Simple HTTP client for the Kilocode Chat Completions API."""
+
+    def __init__(
+        self,
+        api_key: str,
+        base_url: str = "https://api.kilocode.com/v1",
+        timeout: int = 30,
+    ) -> None:
+        if requests is None:  # pragma: no cover - safety guard
+            raise RuntimeError("Requests library is required for KilocodeClient")
+
+        self.api_key = api_key.strip()
+        if not self.api_key:
+            raise ValueError("Kilocode API key must be provided")
+
+        self.base_url = base_url.rstrip("/") or "https://api.kilocode.com/v1"
+        self.timeout = timeout
+
+    def chat_completion(
+        self,
+        prompt: str,
+        *,
+        system_prompt: str,
+        model: str,
+        temperature: float,
+        max_tokens: int,
+    ) -> str:
+        """Send a chat completion request and return the response content."""
+
+        payload = {
+            "model": model,
+            "messages": [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": prompt},
+            ],
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+        }
+
+        data = self._post_json("/chat/completions", payload)
+        return self._extract_message_content(data.get("choices"))
+
+    def _post_json(self, path: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        if requests is None:  # pragma: no cover - safety guard
+            raise RuntimeError("Requests library is unavailable")
+
+        url = f"{self.base_url}{path}"
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+        try:
+            response = requests.post(
+                url,
+                headers=headers,
+                json=payload,
+                timeout=self.timeout,
+            )
+        except RequestException as exc:
+            raise RuntimeError(f"Kilocode request failed: {exc}") from exc
+
+        try:
+            response.raise_for_status()
+        except RequestException as exc:
+            status = getattr(response, "status_code", "unknown")
+            text = getattr(response, "text", "")
+            raise RuntimeError(f"Kilocode HTTP {status}: {text}") from exc
+
+        try:
+            return response.json()
+        except ValueError as exc:
+            raise RuntimeError("Kilocode returned a non-JSON response") from exc
+
+    def _extract_message_content(self, choices: Any) -> str:
+        if not choices:
+            return ""
+
+        first_choice: Any
+        if isinstance(choices, list):
+            first_choice = choices[0] if choices else {}
+        else:
+            first_choice = choices
+
+        if isinstance(first_choice, dict):
+            message = first_choice.get("message", first_choice)
+        else:
+            message = first_choice
+
+        if isinstance(message, dict):
+            content: Any = message.get("content", "")
+        else:
+            content = message or ""
+
+        if isinstance(content, list):
+            logger.warning(
+                "Kilocode API response content is a list; coercing to string for processing.",
+            )
+            content = "".join(str(part) for part in content)
+
+        return str(content).strip()
+
+
+__all__: List[str] = ["KilocodeClient"]

--- a/src/tests/test_kilocode_client.py
+++ b/src/tests/test_kilocode_client.py
@@ -1,0 +1,130 @@
+"""Tests for the Kilocode client wrapper."""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from requests.exceptions import HTTPError, RequestException
+
+from src.llm.kilocode_client import KilocodeClient
+
+
+class TestKilocodeClient(unittest.TestCase):
+    def setUp(self) -> None:
+        self.api_key = "test-key"
+        self.base_url = "https://kilocode.test/v1"
+
+    @patch("src.llm.kilocode_client.requests.post")
+    def test_chat_completion_success(self, post_mock: MagicMock) -> None:
+        response_mock = MagicMock()
+        response_mock.raise_for_status.return_value = None
+        response_mock.json.return_value = {
+            "choices": [{"message": {"content": "Hello world"}}]
+        }
+        post_mock.return_value = response_mock
+
+        client = KilocodeClient(api_key=self.api_key, base_url=self.base_url)
+        result = client.chat_completion(
+            "prompt", system_prompt="system", model="model", temperature=0.7, max_tokens=128
+        )
+
+        self.assertEqual(result, "Hello world")
+        post_mock.assert_called_once_with(
+            "https://kilocode.test/v1/chat/completions",
+            headers={
+                "Authorization": "Bearer test-key",
+                "Content-Type": "application/json",
+            },
+            json={
+                "model": "model",
+                "messages": [
+                    {"role": "system", "content": "system"},
+                    {"role": "user", "content": "prompt"},
+                ],
+                "temperature": 0.7,
+                "max_tokens": 128,
+            },
+            timeout=30,
+        )
+
+    @patch("src.llm.kilocode_client.requests.post")
+    def test_chat_completion_http_error(self, post_mock: MagicMock) -> None:
+        response_mock = MagicMock()
+        response_mock.raise_for_status.side_effect = HTTPError("boom")
+        response_mock.status_code = 500
+        response_mock.text = "internal error"
+        post_mock.return_value = response_mock
+
+        client = KilocodeClient(api_key=self.api_key, base_url=self.base_url)
+        with self.assertRaises(RuntimeError) as ctx:
+            client.chat_completion(
+                "prompt",
+                system_prompt="system",
+                model="model",
+                temperature=0.7,
+                max_tokens=128,
+            )
+        self.assertIn("Kilocode HTTP", str(ctx.exception))
+        self.assertIn("500", str(ctx.exception))
+        self.assertIn("internal error", str(ctx.exception))
+
+    @patch("src.llm.kilocode_client.requests.post")
+    def test_chat_completion_request_exception(self, post_mock: MagicMock) -> None:
+        post_mock.side_effect = RequestException("network down")
+
+        client = KilocodeClient(api_key=self.api_key, base_url=self.base_url)
+        with self.assertRaises(RuntimeError) as ctx:
+            client.chat_completion(
+                "prompt",
+                system_prompt="system",
+                model="model",
+                temperature=0.7,
+                max_tokens=128,
+            )
+        self.assertIn("Kilocode request failed", str(ctx.exception))
+
+    @patch("src.llm.kilocode_client.requests.post")
+    def test_chat_completion_invalid_json(self, post_mock: MagicMock) -> None:
+        response_mock = MagicMock()
+        response_mock.raise_for_status.return_value = None
+        response_mock.json.side_effect = ValueError("bad json")
+        post_mock.return_value = response_mock
+
+        client = KilocodeClient(api_key=self.api_key, base_url=self.base_url)
+        with self.assertRaises(RuntimeError) as ctx:
+            client.chat_completion(
+                "prompt",
+                system_prompt="system",
+                model="model",
+                temperature=0.7,
+                max_tokens=128,
+            )
+        self.assertEqual(str(ctx.exception), "Kilocode returned a non-JSON response")
+
+    @patch("src.llm.kilocode_client.requests.post")
+    def test_extract_message_content_logs_warning_for_list(self, post_mock: MagicMock) -> None:
+        response_mock = MagicMock()
+        response_mock.raise_for_status.return_value = None
+        response_mock.json.return_value = {
+            "choices": [
+                {"message": {"content": ["part1", "part2"]}},
+            ]
+        }
+        post_mock.return_value = response_mock
+
+        client = KilocodeClient(api_key=self.api_key, base_url=self.base_url)
+        with self.assertLogs("src.llm.kilocode_client", level="WARNING") as log_cm:
+            result = client.chat_completion(
+                "prompt",
+                system_prompt="system",
+                model="model",
+                temperature=0.7,
+                max_tokens=128,
+            )
+        self.assertEqual(result, "part1part2")
+        self.assertTrue(any("content is a list" in message for message in log_cm.output))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- refactor the Kilocode ChatGPT 3.5 integration into a dedicated HTTP client and simplify the LLMClient wiring
- ensure the Kilocode client only sends the required authorization header and logs unexpected response formats
- add targeted unit tests covering Kilocode success, HTTP errors, request failures, and invalid JSON responses

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'langchain_community'; ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68e32c6522f0832181263c5914f3c34f